### PR TITLE
feat: move base text field to light dom

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -96,7 +96,7 @@
         <hr />
         <div id="i18n-spanish" class="centered">
         <h2>Month Picker - With months in Spanish </h2>
-        <vcf-month-picker label="Month Picker" @value-changed=${handleValueChange} aria-describedby="spanish-info-text">
+        <vcf-month-picker label="Month Picker" @value-changed=${handleValueChange} aria-describedby="spanish-info-text"
         .i18n=${{
           monthNames: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
               'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web component for selecting year and month",
   "license": "Apache License 2.0",
   "author": "Vaadin Ltd",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "type": "module",
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",
@@ -93,7 +93,8 @@
         {
           "ignorePackages": true
         }
-      ]
+      ],
+      "radix": "off"
     }
   },
   "prettier": {

--- a/src/component/vcf-month-picker-calendar.ts
+++ b/src/component/vcf-month-picker-calendar.ts
@@ -45,7 +45,7 @@ class MonthPickerCalendar extends ElementMixin(
   }
 
   static get version() {
-    return '1.1.0';
+    return '2.0.0';
   }
 
   /**

--- a/src/theme/lumo/vcf-month-picker-styles.ts
+++ b/src/theme/lumo/vcf-month-picker-styles.ts
@@ -26,29 +26,7 @@ registerStyles(
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
     }
-    [part='toggle-button'] {
-      flex: none;
-      width: 1em;
-      height: 1em;
-      line-height: 1;
-      font-size: var(--vcf-month-picker-icon-size);
-      text-align: center;
-      color: var(--lumo-contrast-60pct);
-      transition: 0.2s color;
-      cursor: var(--lumo-clickable-cursor);
-    }
-    [part='toggle-button']::before {
-      display: block;
-      font-family: var(--vcf-month-picker-icons-font-family);
-      content: var(--vcf-month-picker-toggle-calendar-icon);
-    }
-    [part='toggle-button']:hover {
-      color: var(--lumo-body-text-color);
-    }
-    :host([readonly]) [part='toggle-button'] {
-      color: var(--lumo-contrast-20pct);
-      cursor: default;
-    }
+
     :host([readonly]) {
       pointer-events: none;
     }


### PR DESCRIPTION
The change in this PR are meant to expose the month picker's text field to to the light DOM. This adjustment was requested -as part of a suppport request- to enhance accessibility & styling.

This is considered a breaking change so version of the component was updated to 2.0.0.