### PR TITLE
fix: move tslib to dependencies to fix build errors in flow part

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "@vaadin/popover": "^25.0.0",
     "@vaadin/text-field": "^25.0.0",
     "@vaadin/vaadin-themable-mixin": "^25.0.0",
-    "lit": "^3.0.0"
+    "lit": "^3.0.0",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.4.17",
@@ -70,7 +71,6 @@
     "husky": "^4.3.8",
     "lint-staged": "^10.5.4",
     "prettier": "^2.4.1",
-    "tslib": "^2.3.1",
     "typescript": "^5.5.2"
   },
   "customElements": "custom-elements.json",


### PR DESCRIPTION
This PR includes an update necessary for https://github.com/vaadin-component-factory/vcf-month-picker-flow/issues/14